### PR TITLE
Add arm64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,27 @@
 sudo: true
 
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
-    packages:
-    - shellcheck
+dist: bionic
 
 services:
   - docker
 
+arch: 
+  - arm64
+  - amd64
+
+os: linux
+ 
 before_install:
 - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-- sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 - sudo apt-get update
-- sudo apt-get -y install docker-ce
 - docker build -t gluster/client ./gluster-client/
-- docker run -it --name client gluster/client rpm -qa | grep gluster
+- docker run -i --name client gluster/client rpm -qa | grep gluster
+- docker stop client
+- docker rm client
 - docker build -t gluster/centos ./CentOS/
 - docker run -d --name gcentos --privileged gluster/centos
 - sleep 10
-- docker exec -it gcentos systemctl is-active glusterd
+- docker exec -d gcentos systemctl is-active glusterd
 - docker stop gcentos
 - docker rm gcentos
 - sudo mkdir -p /home/centos-glusterd
@@ -28,13 +29,13 @@ before_install:
 - sudo mkdir -p /home/centos-gluster-log
 - docker run -d --name gcentos -v /home/centos-glusterd:/var/lib/glusterd/:z -v /home/centos-gluster-etc:/etc/glusterfs:z -v /home/centos-gluster-log:/var/log/glusterfs --privileged gluster/centos
 - sleep 10
-- docker exec -it gcentos systemctl is-active glusterd
+- docker exec -d gcentos systemctl is-active glusterd
 - docker stop gcentos
 - docker rm gcentos
 - docker build -t gluster/fedora ./Fedora/
 - docker run -d --name gfedora --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro gluster/fedora
 - sleep 10
-- docker exec -it gfedora systemctl is-active glusterd
+- docker exec -d gfedora systemctl is-active glusterd
 - docker stop gfedora
 - docker rm gfedora
 - sudo mkdir -p /home/fedora-glusterd
@@ -42,13 +43,13 @@ before_install:
 - sudo mkdir -p /home/fedora-gluster-log
 - docker run -d --name gfedora -v /home/fedora-glusterd:/var/lib/glusterd/:z -v /home/fedora-gluster-etc:/etc/glusterfs:z -v /home/fedora-gluster-log:/var/log/glusterfs -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged gluster/fedora
 - sleep 10
-- docker exec -it gfedora systemctl is-active glusterd
+- docker exec -d gfedora systemctl is-active glusterd
 - docker stop gfedora
 - docker rm gfedora
 - docker build -t gluster/s3object ./gluster-s3object/CentOS/docker-gluster-s3/
 - docker run -d --name s3object --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -e S3_ACCOUNT=vol -e S3_USER="admin" -e S3_PASSWORD="redhat" gluster/s3object
 - sleep 10
-- docker exec -it s3object systemctl is-active swift-object
+- docker exec -d s3object systemctl is-active swift-object
 
 script:
 - make test

--- a/Fedora/Dockerfile
+++ b/Fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM fedora:33
 
 ENV NAME="gluster-fedora" \
     DESC="GlusterFS on Fedora" \
@@ -31,7 +31,7 @@ COPY fake-disk.sh /usr/libexec/gluster/fake-disk.sh
 
 RUN dnf -y update && \
     sed -i "s/LANG/\#LANG/g" /etc/locale.conf && \
-    dnf -y install systemd-udev glusterfs-server dbus-python nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos xfsprogs && \
+    dnf -y install systemd-udev glusterfs-server python3-dbus nfs-utils attr iputils iproute glusterfs-geo-replication openssh-server openssh-clients cronie tar rsync sos xfsprogs && \
     dnf clean all && \
     sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config && \
     sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service && \

--- a/gluster-client/Dockerfile
+++ b/gluster-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:33
 
 MAINTAINER Humble Devassy Chirammal  <hchiramm@redhat.com>
 
@@ -15,7 +15,7 @@ LABEL architecture="x86_64" \
 ENV container docker
 
 RUN sed -i "s/LANG/\#LANG/g" /etc/locale.conf
-RUN dnf --setopt=tsflags=nodocs -y update &&\
+RUN dnf -y update &&\
 dnf --setopt=tsflags=nodocs -y install wget nfs-utils attr iputils iproute &&\
 dnf install -y glusterfs-fuse &&\
 dnf clean all

--- a/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
+++ b/gluster-s3object/CentOS/docker-gluster-s3/Dockerfile
@@ -19,10 +19,10 @@ LABEL architecture="x86_64" \
       description="gluster-swift image is based on centos image which enables files and directories created on GlusterFS to be accessed as objects via the Swift and S3 API." \
       io.openshift.tags="gluster,glusterfs,gluster-swift"
 
-RUN yum -v --setopt=tsflags=nodocs -y update && \
+RUN yum -y update && \
     yum -v --setopt=tsflags=nodocs -y install centos-release-openstack-queens && \
-    yum -v --setopt=tsflags=nodocs -y install epel-release && \
-    yum -v --setopt=tsflags=nodocs -y install \
+    yum -v --setopt=tsflags=nodocs -y install epel-release python && \
+    yum -v --setopt=tsflags=nodocs -y install --skip-broken\
         openstack-swift openstack-swift-{proxy,account,container,object,plugin-swift3} \
         git memcached python-prettytable python-setuptools && \
     yum -y install systemd && \


### PR DESCRIPTION
Hi

**Package Owner:** Subham Kumar

**PR change Details:**

**Patch Details:** Following files has been changed:

.travis.yml: Add arm support to build docker image and run test on arm64 as well.
Fedora/Dockerfile, gluster-s3object/CentOS/docker-gluster-s3/Dockerfile, gluster-client/Dockerfile: Added suport for arm64.

**PR Description:** Here is my commit message :
Add arm support

**PR Description:**

The following file has been created and modified:

Added arm support in .travis.yml to make the docker image and test it on the arm64 platform as well.
Added arm support in Fedora/Dockerfile, gluster-s3object/CentOS/docker-gluster-s3/Dockerfile, gluster-client/Dockerfile to make the Dockerfile compatible for arm64 and amd64 platform.

**Signed-off-by:** odidev odidev@puresoftware.com

**Reviewer:** Akhand Pratap
Thanks
Subham Kumar